### PR TITLE
Autofocus the `title` field

### DIFF
--- a/Resources/views/admin/menuitems/partials/create-trans-fields.blade.php
+++ b/Resources/views/admin/menuitems/partials/create-trans-fields.blade.php
@@ -1,6 +1,6 @@
 <div class='form-group{{ $errors->has("{$lang}[title]") ? ' has-error' : '' }}'>
     {!! Form::label("{$lang}[title]", trans('menu::menu.form.title')) !!}
-    {!! Form::text("{$lang}[title]", Input::old("{$lang}[title]"), ['class' => 'form-control', 'placeholder' => trans('menu::menu.form.title')]) !!}
+    {!! Form::text("{$lang}[title]", Input::old("{$lang}[title]"), ['class' => 'form-control', 'placeholder' => trans('menu::menu.form.title'), 'autofocus']) !!}
     {!! $errors->first("{$lang}[title]", '<span class="help-block">:message</span>') !!}
 </div>
 <div class="form-group">


### PR DESCRIPTION
This is very useful when using shortcuts (eg: `c`) - it means you don't have to touch the mouse at all to start typing.