### PR TITLE
Fix duplicated menu items in submenus.

### DIFF
--- a/Providers/MenuServiceProvider.php
+++ b/Providers/MenuServiceProvider.php
@@ -124,8 +124,6 @@ class MenuServiceProvider extends ServiceProvider
      */
     private function addSubItemToMenu(Menuitem $child, PingpongMenuItem $sub)
     {
-        $sub->url($child->uri, $child->title);
-
         if ($this->hasChildren($child)) {
             $this->addChildrenToMenu($child->title, $child->items, $sub);
         } else {


### PR DESCRIPTION
Submenu items (and sub-submenu items) were being duplicated on render.

Signed-off-by: Micheal Mand <micheal@kmdwebdesigns.com>