### PR TITLE
Fix database schema so PingPong/Menus/MenuItem correctly returns icon string

### DIFF
--- a/Database/Migrations/2016_01_26_102307_update_icon_column_on_menuitems_table.php
+++ b/Database/Migrations/2016_01_26_102307_update_icon_column_on_menuitems_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateIconColumnOnMenuitemsTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('menu__menuitems', function(Blueprint $table)
+        {
+            $table->string('icon')->nullable()->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('menu__menuitems', function(Blueprint $table)
+        {
+             $table->string('icon')->default('')->nullable(false)->change();
+        });
+    }
+
+}


### PR DESCRIPTION
Currently, the icon column setup (**not nullable, defaults to empty string**) causes the menu builder classes to incorrectly return `<i class=""></i>` for empty icon. See Pingpong\Menus\MenuItem:
```php
    public function getIcon($default = null)
    {
        return !is_null($this->icon) ? '<i class="'.$this->icon.'"></i>' : $default;
    }
```
If an "empty icon" is a desired behaviour, a custom presenter should be used that makes use of the "default" parameter.
Currently all the presenters render an "empty icon" regardless of the value of the icon property because `null !== ""`.