### PR TITLE
Change API middleware to only check for a valid token

### DIFF
--- a/Http/apiRoutes.php
+++ b/Http/apiRoutes.php
@@ -3,13 +3,15 @@
 use Illuminate\Routing\Router;
 
 /** @var Router $router */
-$router->group(['prefix' => '/menuitem', 'middleware' => 'api.token.admin'], function (Router $router) {
+$router->group(['prefix' => '/menuitem', 'middleware' => 'api.token'], function (Router $router) {
     $router->post('/update', [
         'as' => 'api.menuitem.update',
         'uses' => 'MenuItemController@update',
+        'middleware' => 'token-can:menu.menuitems.edit',
     ]);
     $router->post('/delete', [
         'as' => 'api.menuitem.delete',
         'uses' => 'MenuItemController@delete',
+        'middleware' => 'token-can:menu.menuitems.destroy',
     ]);
 });


### PR DESCRIPTION
As per https://github.com/AsgardCms/Platform/issues/229, any API action
was limited to people in the "Admin" group. If the group name was changed
or the user wasn't an admin they couldn't do any API action at all, even
if they had correct permissions.
